### PR TITLE
Fix two bugs

### DIFF
--- a/QuickPay/QuickPay.php
+++ b/QuickPay/QuickPay.php
@@ -1,33 +1,33 @@
 <?php
 namespace QuickPay;
 
-require_once( 'api/constants.php' );
-require_once( 'api/exception.php' );
-require_once( 'api/client.php' );
-require_once( 'api/request.php' );
-require_once( 'api/response.php' );
+require_once( 'api/Constants.php' );
+require_once( 'api/Exception.php' );
+require_once( 'api/Client.php' );
+require_once( 'api/Request.php' );
+require_once( 'api/Response.php' );
 
 use QuickPay\API\Client;
-use QuickPay\API\Request; 
+use QuickPay\API\Request;
 
-class QuickPay 
-{ 
+class QuickPay
+{
     /**
      * Contains the QuickPay_Request object
      * @access public
      **/
     public $request;
-  	
-    
+
+
     /**
 	* __construct function.
-	* 
-	* Instantiates the main class. 
-	* Creates a client which is passed to the request construct. 
+	*
+	* Instantiates the main class.
+	* Creates a client which is passed to the request construct.
 	*
 	* @access public
-	*/     
-    public function __construct( $auth_string = '' ) 
+	*/
+    public function __construct( $auth_string = '' )
     {
         $client = new Client( $auth_string );
         $this->request = new Request( $client );

--- a/QuickPay/api/Request.php
+++ b/QuickPay/api/Request.php
@@ -17,24 +17,24 @@ class Request
     /**
      * Contains QuickPay_Client instance
      * @access protected
-     */   
+     */
     protected $client;
-   
-    
+
+
     /**
 	* __construct function.
-	* 
+	*
 	* Instantiates the object
 	*
 	* @access public
 	* @return object
-	*/     
+	*/
     public function __construct( $client )
     {
         $this->client = $client;
     }
-    
-    
+
+
     /**
 	* get function.
 	*
@@ -66,7 +66,7 @@ class Request
         // Start the request and return the response
         return $this->execute('GET');
     }
- 
+
 
    	/**
 	* post function.
@@ -75,16 +75,16 @@ class Request
 	*
 	* @access public
 	* @return object
-	*/    
-    public function post( $path, $form = array() ) 
+	*/
+    public function post( $path, $form = array() )
     {
         // Set the request params
         $this->set_url( $path );
 
         // Start the request and return the response
         return $this->execute('POST', $form);
-    }	
-    
+    }
+
 
    	/**
 	* put function.
@@ -93,17 +93,17 @@ class Request
 	*
 	* @access public
 	* @return object
-	*/    
-    public function put( $path, $form = array() ) 
+	*/
+    public function put( $path, $form = array() )
     {
         // Set the request params
         $this->set_url( $path );
 
         // Start the request and return the response
         return $this->execute('PUT', $form);
-    }	
-    
-    
+    }
+
+
    	/**
 	* patch function.
 	*
@@ -111,17 +111,17 @@ class Request
 	*
 	* @access public
 	* @return object
-	*/    
-    public function patch( $path, $form = array() ) 
+	*/
+    public function patch( $path, $form = array() )
     {
         // Set the request params
         $this->set_url( $path );
 
         // Start the request and return the response
         return $this->execute('PATCH', $form);
-    }	
-    
-    
+    }
+
+
    	/**
 	* delete function.
 	*
@@ -129,8 +129,8 @@ class Request
 	*
 	* @access public
 	* @return object
-	*/    
-    public function delete( $path, $form = array() ) 
+	*/
+    public function delete( $path, $form = array() )
     {
         // Set the request params
         $this->set_url( $path );
@@ -138,8 +138,8 @@ class Request
         // Start the request and return the response
         return $this->execute('DELETE', $form);
     }
-    
-    
+
+
   	/**
 	* set_url function.
 	*
@@ -147,13 +147,13 @@ class Request
 	*
 	* @access protected
 	* @return void
-	*/   
-    protected function set_url( $params ) 
+	*/
+    protected function set_url( $params )
     {
         curl_setopt( $this->client->ch, CURLOPT_URL, Constants::API_URL . trim( $params, '/' ) );
     }
-    
-    
+
+
    	/**
 	* execute function.
 	*
@@ -163,8 +163,8 @@ class Request
 	* @param  string $request_type
 	* @param  array  $form
 	* @return object
-	*/   	
- 	protected function execute( $request_type, $form = array() ) 
+	*/
+ 	protected function execute( $request_type, $form = array() )
  	{
  		// Set the HTTP request type
  		curl_setopt( $this->client->ch, CURLOPT_CUSTOMREQUEST, $request_type );
@@ -178,9 +178,14 @@ class Request
  		// Execute the request
  		$response_data = curl_exec( $this->client->ch );
 
+ 		if (curl_errno($this->client->ch) !== 0) {
+ 			//An error occurred
+ 			throw new Exception(curl_error($this->client->ch), curl_errno($this->client->ch));
+ 		}
+
  		// Retrieve the HTTP response code
  		$response_code = (int) curl_getinfo( $this->client->ch, CURLINFO_HTTP_CODE );
-        
+
  		// Return the response object.
  		return new Response( $response_code, $response_data );
  	}


### PR DESCRIPTION
I took the liberty of fixing 2 problems:

1) requiring files with lowercase names, when the actual filenames are uppercased. Fixed by uppercasing the require_once statements.

2) Throw an exception when SSL certificate verification failed (only observed on Windows) - or for that matter when any curl-error occurs.

Trailing whitespace removed as an artifact of my editor.