### PR TITLE
Support for parameters of type object

### DIFF
--- a/QuickPay/api/Request.php
+++ b/QuickPay/api/Request.php
@@ -157,7 +157,7 @@ class Request
  		// If additional data is delivered, we will send it along with the API request
  		if( is_array( $form ) && ! empty( $form ) )
  		{
- 			curl_setopt( $this->client->ch, CURLOPT_POSTFIELDS, $form );
+ 			curl_setopt( $this->client->ch, CURLOPT_POSTFIELDS, http_build_query($form) );
  		}
 
  		// Execute the request


### PR DESCRIPTION
 - eg POST /payments with variables.

Example:
		$form = [
			'currency' => 'DKK',
			'order_id' => '20150630-1',
			'variables' => [
				'foo' => 'bar',
				'more' => 'less'
			]
		];
		$response = $client->request->post('/payments', $form);