### PR TITLE
Allow query parameters to GET requests to be passed as array.

### DIFF
--- a/QuickPay/api/Request.php
+++ b/QuickPay/api/Request.php
@@ -41,10 +41,25 @@ class Request
 	* Performs an API GET request
 	*
 	* @access public
+	* @param  string $path
+	* @param  array  $query
 	* @return object
 	*/    
-    public function get( $path ) 
+    public function get( $path, $query = array() )
     {
+		// Add query parameters to $path?
+		if ( $query )
+		{
+			if (strpos($path, '?') === false )
+			{
+				$path .= '?' . http_build_query($query);
+			}
+			else
+			{
+				$path .= ini_get('arg_separator.output') . http_build_query($query);
+			}
+		}
+
         // Set the request params
         $this->set_url( $path );
 


### PR DESCRIPTION
Example:
		$query = [
			'page' => 2,
			'page_size' => 100,
		];
		$response = $client->request->get('/payments', $query);