### PR TITLE
Add Client::set_headers with the possibility to set additional custom…

### DIFF
--- a/QuickPay/API/Client.php
+++ b/QuickPay/API/Client.php
@@ -1,57 +1,56 @@
 <?php
 namespace QuickPay\API;
 /**
- * @class 		QuickPay_Client
- * @since		1.0.0
- * @package		QuickPay
- * @category	Class
- * @author 		Patrick Tolvstein, Perfect Solution ApS
+ * @class       QuickPay_Client
+ * @since       1.0.0
+ * @package     QuickPay
+ * @category    Class
+ * @author      Patrick Tolvstein, Perfect Solution ApS
  * @docs        http://tech.quickpay.net/api/
  */
-class Client 
+class Client
 {
     /**
      * Contains cURL instance
      * @access public
-     */    
+     */
     public $ch;
- 
+
     /**
      * Contains the authentication string
      * @access protected
-     */  
+     */
     protected $auth_string;
-    
-    
- 	/**
-	* __construct function.
-	*
-	* Instantiate object
-	*
-	* @access public
-	*/
+
+    /**
+    * __construct function.
+    *
+    * Instantiate object
+    *
+    * @access public
+    */
     public function __construct( $auth_string = '' )
     {
         // Check if lib cURL is enabled
-        if( ! function_exists('curl_init') ) 
+        if( ! function_exists('curl_init') )
         {
             throw new Exception( 'Lib cURL must be enabled on the server' );
         }
-        
+
         // Set auth string property
         $this->auth_string = $auth_string;
-        
+
         // Instantiate cURL object
         $this->authenticate();
     }
-    
-	/**
-	* shutdown function.
-	*
-	* Closes the current cURL connection
-	*
-	* @access public
-	*/    
+
+    /**
+    * shutdown function.
+    *
+    * Closes the current cURL connection
+    *
+    * @access public
+    */
     public function shutdown()
     {
         if( ! empty( $this->ch ) )
@@ -59,36 +58,49 @@ class Client
             curl_close( $this->ch );
         }
     }
-    
-      
- 	/**
-	* authenticate function.
-	*
-	* Create a cURL instance with authentication headers
-	*
-	* @access public
-	*/
+
+
+    /**
+    * authenticate function.
+    *
+    * Create a cURL instance with authentication headers
+    *
+    * @access public
+    */
     protected function authenticate()
     {
         $this->ch = curl_init();
-        
-        $headers = array(
-            'Accept-Version: v10',
-            'Accept: application/json', 
-        );
-
-        if( ! empty($this->auth_string)) 
-        {
-            $headers[] = 'Authorization: Basic ' . base64_encode( $this->auth_string );
-        }
 
         $options = array(
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_HTTPAUTH => CURLAUTH_BASIC,
-            CURLOPT_HTTPHEADER => $headers
-        ); 
-        
+            CURLOPT_HTTPAUTH => CURLAUTH_BASIC
+        );
+
         curl_setopt_array( $this->ch, $options );
+    }
+
+    public function set_headers( $additional_headers = array() )
+    {
+        $headers = array(
+            'Accept-Version: v10',
+            'Accept: application/json',
+            'Content-Type: application/json',
+        );
+
+        if( ! empty($this->auth_string))
+        {
+            $headers[] = 'Authorization: Basic ' . base64_encode( $this->auth_string );
+        }
+
+        if( ! empty( $additional_headers ) )
+        {
+            foreach( $additional_headers as $additional_header )
+            {
+                $headers[] = $additional_header;
+            }
+        }
+
+        curl_setopt( $this->ch, CURLOPT_HTTPHEADER, $headers);
     }
 }

--- a/QuickPay/API/Request.php
+++ b/QuickPay/API/Request.php
@@ -171,7 +171,17 @@ class Request
  		// If additional data is delivered, we will send it along with the API request
  		if( is_array( $form ) && ! empty( $form ) )
  		{
- 			curl_setopt( $this->client->ch, CURLOPT_POSTFIELDS, http_build_query($form) );
+ 			$json_data = json_encode( $form );
+ 			curl_setopt( $this->client->ch, CURLOPT_POSTFIELDS, $json_data );
+ 			$this->client->set_headers(
+ 				array(
+ 					'Content-Length: ' . strlen($json_data)
+ 				)
+ 			);
+ 		}
+ 		else
+ 		{
+ 			$this->client->set_headers();
  		}
 
 		// Store received headers in temporary memory file, remember sent headers


### PR DESCRIPTION
… headers. Used in Request::execute to possibly set the Content-Length of the JSON request body when sending form data

Also added the header Content-Type to align the request headers with the requirements of the QuickPay API docs
