### PR TITLE
Update composer config with proper lib-curl requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PHP-SDK to communicate with the payment provider QuickPay",
     "homepage": "https://github.com/QuickPay/quickpay-php-client",
     "require": {
-        "lib/curl": "dev-master"
+        "lib-curl": "*"
     },
     "require-dev" : {
     	"phpunit/phpunit": "4.8.*@dev",


### PR DESCRIPTION
PHP libs are required in the lib-<name> format, see https://getcomposer.org/doc/02-libraries.md#platform-packages