### PR TITLE
Composer does not accept uppercase characters in name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "QuickPay/quickpay-php-client",
+    "name": "quickpay/quickpay-php-client",
     "type": "library",
     "description": "PHP-SDK to communicate with the payment provider QuickPay",
     "homepage": "https://github.com/QuickPay/quickpay-php-client",


### PR DESCRIPTION
This is necessary for it to build on composer. @ta could you merge it promptly.