### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,22 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
   - nightly
 
 matrix:
   include:
+    - php: 5.5
+      dist: trusty
     - php: hhvm
       dist: trusty
   allow_failures:
+    - php: hhvm
     - php: nightly
   fast_finish: true
 


### PR DESCRIPTION
PHP 5.5 must be build on trusty.
hhvm fails - don't know why.
7.[1234] added.