### PR TITLE
Feature/get response headers

### DIFF
--- a/QuickPay/API/Response.php
+++ b/QuickPay/API/Response.php
@@ -193,7 +193,7 @@ class Response
      *
      * @param string|false $key
      */
-    public function getHeader(string $key)
+    public function getHeader($key)
     {
         $result = false;
         $headers = $this->getHeaders();

--- a/QuickPay/API/Response.php
+++ b/QuickPay/API/Response.php
@@ -152,4 +152,56 @@ class Response
 
         return true;
     }
+
+    /**
+     * getHeaders
+     *
+     * Returns headers from response
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        $result = [];
+
+        if ($headers = $this->received_headers) {
+            // Filter out HTTP status and empty header lines
+            $headers = array_filter(explode("\r\n", $headers), function ($header) {
+                return empty($header) == false && strpos($header, ':');
+            });
+
+            // Build two dimensional key value pair array of headers
+            foreach ($headers as $index => $header) {
+                $headerArray = explode(':', $header);
+                $key = trim($headerArray[0]);
+                $value = trim($headerArray[1]);
+
+                $headers[$key] = $value;
+                unset($headers[$index]);
+            }
+
+            $result = $headers;
+        }
+
+        return $result;
+    }
+
+    /**
+     * getHeader
+     *
+     * Gets header from received headers
+     *
+     * @param string|false $key
+     */
+    public function getHeader(string $key)
+    {
+        $result = false;
+        $headers = $this->getHeaders();
+
+        if (isset($headers[$key])) {
+            $result = $headers[$key];
+        }
+
+        return $result;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ if ($status == 200) {
 }
 ```
 
+Getting `HTTP response headers`:
+
+```php5
+$response = $client->request->get('/payments');
+
+// Get all headers as key-value pair array
+$headers = $response->getHeaders();
+
+// Get a single header or the default value of false (e.g. Server)
+$header = $response->getHeader('Server');
+```
+
 The returned response object supports 3 different ways of returning the response body, `asRaw()`, `asObject`, `asArray()`.
 
 ```php5

--- a/Tests/api/ResponseTest.php
+++ b/Tests/api/ResponseTest.php
@@ -6,6 +6,9 @@ use QuickPay\API\Response;
 
 class ResponseTest extends \PHPUnit_Framework_TestCase
 {
+    private $responseTestHeaders = "Server: nginx
+    Date: Fri, 09 Apr 2021 09:13:04 GMT
+    Content-Type: application/json";
     private $responseTestData = '{ "key1": "value1", "key2": "value2" }';
 
     /**
@@ -107,5 +110,23 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_int($statusCode));
         $this->assertTrue(is_array($headers));
         $this->assertTrue(is_string($responseRaw));
+    }
+    
+    public function testReturnOfResponseHeadersArrayKeyValuePairArray()
+    {
+        $response = new Response(200, '', $this->responseTestHeaders, $this->responseTestData);
+        $headers = $response->getHeaders();
+        
+        $isAssociativeArray = (bool)count(array_filter(array_keys($headers), 'is_string')) > 0;
+
+        $this->assertTrue($isAssociativeArray);
+    }
+
+    public function testReturnOfResponseHeaderServer()
+    {
+        $response = new Response(200, '', $this->responseTestHeaders, $this->responseTestData);
+        $header = $response->getHeader('Server');
+
+        $this->assertTrue(is_string($header));
     }
 }


### PR DESCRIPTION
## Description

This feature makes it possible to get response headers from a response.

## Examples of usage

```php5
$response = $client->request->get('/payments');

// Get all headers as key-value pair array
$headers = $response->getHeaders();

// Get a single header by it's key/name (case-sensitive)
$serverHeader = $response->getHeader('Server');
```